### PR TITLE
Striping markdown file extensions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -131,7 +131,7 @@ runs:
         path: ${{ env.NEW_WIKI_CHECKOUT_PATH }}
         
     - name: Stripping MarkDown file extensions...
-      uses:  impresscms-dev/strip-markdown-extensions-from-links-action@main
+      uses: impresscms-dev/strip-markdown-extensions-from-links-action@v0.1
       with:
         path: ${{ env.NEW_WIKI_CHECKOUT_PATH }}
 

--- a/action.yml
+++ b/action.yml
@@ -129,6 +129,11 @@ runs:
       uses: impresscms-dev/flattern-markdown-folder-structure-action@v0.2
       with:
         path: ${{ env.NEW_WIKI_CHECKOUT_PATH }}
+        
+    - name: Stripping MarkDown file extensions...
+      uses:  impresscms-dev/strip-markdown-extensions-from-links-action@main
+      with:
+        path: ${{ env.NEW_WIKI_CHECKOUT_PATH }}
 
     - name: Moving old .git data to new docs folder...
       run: mv "$OLD_WIKI_CHECKOUT_PATH"/.git "$NEW_WIKI_CHECKOUT_PATH/"


### PR DESCRIPTION
Previously there was a bug that some wiki pages were opened not as regular web pages but as markdown content. A new extra processing step fixes such bugs.